### PR TITLE
feat: [BREAKING] HTTP 410 para controladores asociados a notificaciones

### DIFF
--- a/controllers/metodo_http.go
+++ b/controllers/metodo_http.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -29,11 +30,13 @@ func (c *MetodoHttpController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create MetodoHttp
-// @Param	body		body 	models.MetodoHttp	true		"body for MetodoHttp content"
-// @Success 201 {int} models.MetodoHttp
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router / [post]
 func (c *MetodoHttpController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.MetodoHttp
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddMetodoHttp(&v); err == nil {
@@ -57,11 +60,13 @@ func (c *MetodoHttpController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get MetodoHttp by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object} models.MetodoHttp
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [get]
 func (c *MetodoHttpController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetMetodoHttpById(id)
@@ -79,16 +84,13 @@ func (c *MetodoHttpController) GetOne() {
 // GetAll ...
 // @Title Get All
 // @Description get MetodoHttp
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.MetodoHttp
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *MetodoHttpController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -148,12 +150,13 @@ func (c *MetodoHttpController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the MetodoHttp
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.MetodoHttp	true		"body for MetodoHttp content"
-// @Success 200 {object} models.MetodoHttp
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *MetodoHttpController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.MetodoHttp{Id: id}
@@ -178,11 +181,13 @@ func (c *MetodoHttpController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the MetodoHttp
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *MetodoHttpController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteMetodoHttp(id); err == nil {

--- a/controllers/notificacion.go
+++ b/controllers/notificacion.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -28,11 +29,13 @@ func (c *NotificacionController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create Notificacion
-// @Param	body		body 	models.Notificacion	true		"body for Notificacion content"
-// @Success 201 {int} models.Notificacion
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router / [post]
 func (c *NotificacionController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.Notificacion
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddNotificacion(&v); err == nil {
@@ -56,11 +59,13 @@ func (c *NotificacionController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get Notificacion by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object} models.Notificacion
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [get]
 func (c *NotificacionController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetNotificacionById(id)
@@ -78,16 +83,13 @@ func (c *NotificacionController) GetOne() {
 // GetAll ...
 // @Title Get All
 // @Description get Notificacion
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.Notificacion
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *NotificacionController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -147,12 +149,13 @@ func (c *NotificacionController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the Notificacion
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.Notificacion	true		"body for Notificacion content"
-// @Success 200 {object} models.Notificacion
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *NotificacionController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.Notificacion{Id: id}
@@ -177,11 +180,13 @@ func (c *NotificacionController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the Notificacion
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *NotificacionController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteNotificacion(id); err == nil {

--- a/controllers/notificacion_configuracion.go
+++ b/controllers/notificacion_configuracion.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -30,11 +31,13 @@ func (c *NotificacionConfiguracionController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create NotificacionConfiguracion
-// @Param	body		body 	models.NotificacionConfiguracion	true		"body for NotificacionConfiguracion content"
-// @Success 201 {int} models.NotificacionConfiguracion
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router / [post]
 func (c *NotificacionConfiguracionController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.NotificacionConfiguracion
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddNotificacionConfiguracion(&v); err == nil {
@@ -58,11 +61,13 @@ func (c *NotificacionConfiguracionController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get NotificacionConfiguracion by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object} models.NotificacionConfiguracion
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [get]
 func (c *NotificacionConfiguracionController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetNotificacionConfiguracionById(id)
@@ -80,11 +85,13 @@ func (c *NotificacionConfiguracionController) GetOne() {
 // GetConfiguracion ...
 // @Title getConfiguracion
 // @Description get a configuration
-// @Param	body		body 	models.ShowConfiguration	true		"body for ShowConfiguration content"
-// @Success 200 {string} get success!
-// @Failure 403 profile is empty
+// @Failure 410 Controlador archivado
 // @router /getConfiguracion/ [post]
 func (c *NotificacionConfiguracionController) GetConfiguracion() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v map[string]interface{}
 	// fields: col1,col2,entity.col3
 	beego.Info(c.Ctx.Input.RequestBody)
@@ -105,16 +112,13 @@ func (c *NotificacionConfiguracionController) GetConfiguracion() {
 // GetAll ...
 // @Title Get All
 // @Description get NotificacionConfiguracion
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.NotificacionConfiguracion
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *NotificacionConfiguracionController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -174,12 +178,13 @@ func (c *NotificacionConfiguracionController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the NotificacionConfiguracion
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.NotificacionConfiguracion	true		"body for NotificacionConfiguracion content"
-// @Success 200 {object} models.NotificacionConfiguracion
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *NotificacionConfiguracionController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.NotificacionConfiguracion{Id: id}
@@ -204,11 +209,13 @@ func (c *NotificacionConfiguracionController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the NotificacionConfiguracion
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *NotificacionConfiguracionController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteNotificacionConfiguracion(id); err == nil {

--- a/controllers/notificacion_configuracion_perfil.go
+++ b/controllers/notificacion_configuracion_perfil.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -29,11 +30,13 @@ func (c *NotificacionConfiguracionPerfilController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create NotificacionConfiguracionPerfil
-// @Param	body		body 	models.NotificacionConfiguracionPerfil	true		"body for NotificacionConfiguracionPerfil content"
-// @Success 201 {int} models.NotificacionConfiguracionPerfil
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router / [post]
 func (c *NotificacionConfiguracionPerfilController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.NotificacionConfiguracionPerfil
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddNotificacionConfiguracionPerfil(&v); err == nil {
@@ -57,11 +60,13 @@ func (c *NotificacionConfiguracionPerfilController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get NotificacionConfiguracionPerfil by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object} models.NotificacionConfiguracionPerfil
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [get]
 func (c *NotificacionConfiguracionPerfilController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetNotificacionConfiguracionPerfilById(id)
@@ -79,16 +84,13 @@ func (c *NotificacionConfiguracionPerfilController) GetOne() {
 // GetAll ...
 // @Title Get All
 // @Description get NotificacionConfiguracionPerfil
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.NotificacionConfiguracionPerfil
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *NotificacionConfiguracionPerfilController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -148,12 +150,13 @@ func (c *NotificacionConfiguracionPerfilController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the NotificacionConfiguracionPerfil
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.NotificacionConfiguracionPerfil	true		"body for NotificacionConfiguracionPerfil content"
-// @Success 200 {object} models.NotificacionConfiguracionPerfil
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *NotificacionConfiguracionPerfilController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.NotificacionConfiguracionPerfil{Id: id}
@@ -178,11 +181,13 @@ func (c *NotificacionConfiguracionPerfilController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the NotificacionConfiguracionPerfil
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *NotificacionConfiguracionPerfilController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteNotificacionConfiguracionPerfil(id); err == nil {

--- a/controllers/notificacion_estado.go
+++ b/controllers/notificacion_estado.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -29,11 +30,13 @@ func (c *NotificacionEstadoController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create NotificacionEstado
-// @Param	body		body 	models.NotificacionEstado	true		"body for NotificacionEstado content"
-// @Success 201 {int} models.NotificacionEstado
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router / [post]
 func (c *NotificacionEstadoController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.NotificacionEstado
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddNotificacionEstado(&v); err == nil {
@@ -57,11 +60,13 @@ func (c *NotificacionEstadoController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get NotificacionEstado by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object} models.NotificacionEstado
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [get]
 func (c *NotificacionEstadoController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetNotificacionEstadoById(id)
@@ -79,16 +84,13 @@ func (c *NotificacionEstadoController) GetOne() {
 // GetAll ...
 // @Title Get All
 // @Description get NotificacionEstado
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.NotificacionEstado
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *NotificacionEstadoController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -148,12 +150,13 @@ func (c *NotificacionEstadoController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the NotificacionEstado
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.NotificacionEstado	true		"body for NotificacionEstado content"
-// @Success 200 {object} models.NotificacionEstado
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *NotificacionEstadoController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.NotificacionEstado{Id: id}
@@ -178,11 +181,13 @@ func (c *NotificacionEstadoController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the NotificacionEstado
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *NotificacionEstadoController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteNotificacionEstado(id); err == nil {

--- a/controllers/notificacion_estado_usuario.go
+++ b/controllers/notificacion_estado_usuario.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -30,11 +31,16 @@ func (c *NotificacionEstadoUsuarioController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create NotificacionEstadoUsuario
+// @Failure 410 Controlador archivado
 // @Param	body		body 	models.NotificacionEstadoUsuario	true		"body for NotificacionEstadoUsuario content"
 // @Success 201 {int} models.NotificacionEstadoUsuario
 // @Failure 400 the request contains incorrect syntax
 // @router / [post]
 func (c *NotificacionEstadoUsuarioController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.NotificacionEstadoUsuario
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddNotificacionEstadoUsuario(&v); err == nil {
@@ -58,11 +64,16 @@ func (c *NotificacionEstadoUsuarioController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get NotificacionEstadoUsuario by id
+// @Failure 410 Controlador archivado
 // @Param	id		path 	string	true		"The key for staticblock"
 // @Success 200 {object} models.NotificacionEstadoUsuario
 // @Failure 404 not found resource
 // @router /:id [get]
 func (c *NotificacionEstadoUsuarioController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetNotificacionEstadoUsuarioById(id)
@@ -80,16 +91,13 @@ func (c *NotificacionEstadoUsuarioController) GetOne() {
 // GetAll ...
 // @Title Get All
 // @Description get NotificacionEstadoUsuario
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.NotificacionEstadoUsuario
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *NotificacionEstadoUsuarioController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -149,12 +157,13 @@ func (c *NotificacionEstadoUsuarioController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the NotificacionEstadoUsuario
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.NotificacionEstadoUsuario	true		"body for NotificacionEstadoUsuario content"
-// @Success 200 {object} models.NotificacionEstadoUsuario
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *NotificacionEstadoUsuarioController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.NotificacionEstadoUsuario{Id: id}
@@ -179,11 +188,13 @@ func (c *NotificacionEstadoUsuarioController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the NotificacionEstadoUsuario
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *NotificacionEstadoUsuarioController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteNotificacionEstadoUsuario(id); err == nil {
@@ -200,12 +211,13 @@ func (c *NotificacionEstadoUsuarioController) Delete() {
 // getOldNotification ...
 // @Title getOldNotification
 // @Description get all old notification
-// @Param	roles		path 	string	true		"The profile you want to consult"
-// @Param	usuario		path 	string	true		"The user you want to consult"
-// @Success 200 {string} get success!
-// @Failure 403 profile is empty
+// @Failure 410 Controlador archivado
 // @router /getOldNotification/:roles/:usuario [get]
 func (c *NotificacionEstadoUsuarioController) GetOldNotification() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	rolesStr := c.Ctx.Input.Param(":roles")
 	userStr := c.Ctx.Input.Param(":usuario")
 	c.Data["json"] = notimanager.GetOldNotification(rolesStr, userStr)
@@ -214,11 +226,13 @@ func (c *NotificacionEstadoUsuarioController) GetOldNotification() {
 // pushNotificationUser ...
 // @Title pushNotificationUser
 // @Description create pushNotificationUser
-// @Param	body		body 	models.NotificacionUsuarioMasiva	true		"body for NotificacionEstadoUsuario content"
-// @Success 201 {int} models.NotificacionEstadoUsuario
-// @Failure 403 body is empty
+// @Failure 410 Controlador archivado
 // @router /pushNotificationUser [post]
 func (c *NotificacionEstadoUsuarioController) PushNotificationUser() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.NotificacionUsuarioMasiva
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if err := notimanager.PushNotificationUser(&v); err == nil {
@@ -235,11 +249,13 @@ func (c *NotificacionEstadoUsuarioController) PushNotificationUser() {
 // changeStateNoView ...
 // @Title changeStateNoView
 // @Description change state of notifications
-// @Param	usuario		path 	string	true		"The user you want to update"
-// @Success 200 {string} get success!
-// @Failure 403 body is empty
+// @Failure 410 Controlador archivado
 // @router /changeStateNoView/:usuario [post]
 func (c *NotificacionEstadoUsuarioController) ChangeStateNoView() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	userStr := c.Ctx.Input.Param(":usuario")
 	c.Data["json"] = notimanager.ChangeStateNoView(userStr)
 }
@@ -247,11 +263,13 @@ func (c *NotificacionEstadoUsuarioController) ChangeStateNoView() {
 // ChangeStateToView ...
 // @Title changeStateNoView
 // @Description create NotificacionEstadoUsuario
-// @Param    id        path     int    true        "The notification you want to update"
-// @Success 201 {int} models.NotificacionEstadoUsuario
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /changeStateToView/:id [get]
 func (c *NotificacionEstadoUsuarioController) ChangeStateToView() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	c.Data["json"] = notimanager.ChangeStateToView(idStr)
 }

--- a/controllers/notificacion_tipo.go
+++ b/controllers/notificacion_tipo.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -31,11 +32,13 @@ func (c *NotificacionTipoController) URLMapping() {
 // Post ...
 // @Title Post
 // @Description create NotificacionTipo
-// @Param	body		body 	models.NotificacionTipo	true		"body for NotificacionTipo content"
-// @Success 201 {int} models.NotificacionTipo
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router / [post]
 func (c *NotificacionTipoController) Post() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var v models.NotificacionTipo
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
 		if _, err := models.AddNotificacionTipo(&v); err == nil {
@@ -57,11 +60,13 @@ func (c *NotificacionTipoController) Post() {
 // GetOne ...
 // @Title Get One
 // @Description get NotificacionTipo by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object} models.NotificacionTipo
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [get]
 func (c *NotificacionTipoController) GetOne() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v, err := models.GetNotificacionTipoById(id)
@@ -79,16 +84,13 @@ func (c *NotificacionTipoController) GetOne() {
 // GetAll ...
 // @Title Get All
 // @Description get NotificacionTipo
-// @Param	query	query	string	false	"Filter. e.g. col1:v1,col2:v2 ..."
-// @Param	fields	query	string	false	"Fields returned. e.g. col1,col2 ..."
-// @Param	sortby	query	string	false	"Sorted-by fields. e.g. col1,col2 ..."
-// @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
-// @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
-// @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.NotificacionTipo
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router / [get]
 func (c *NotificacionTipoController) GetAll() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	var fields []string
 	var sortby []string
 	var order []string
@@ -148,12 +150,13 @@ func (c *NotificacionTipoController) GetAll() {
 // Put ...
 // @Title Put
 // @Description update the NotificacionTipo
-// @Param	id		path 	string	true		"The id you want to update"
-// @Param	body		body 	models.NotificacionTipo	true		"body for NotificacionTipo content"
-// @Success 200 {object} models.NotificacionTipo
-// @Failure 400 the request contains incorrect syntax
+// @Failure 410 Controlador archivado
 // @router /:id [put]
 func (c *NotificacionTipoController) Put() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	v := models.NotificacionTipo{Id: id}
@@ -178,11 +181,13 @@ func (c *NotificacionTipoController) Put() {
 // Delete ...
 // @Title Delete
 // @Description delete the NotificacionTipo
-// @Param	id		path 	string	true		"The id you want to delete"
-// @Success 200 {string} delete success!
-// @Failure 404 not found resource
+// @Failure 410 Controlador archivado
 // @router /:id [delete]
 func (c *NotificacionTipoController) Delete() {
+	c.Ctx.Output.SetStatus(http.StatusGone)
+	c.ServeJSON()
+	return
+
 	idStr := c.Ctx.Input.Param(":id")
 	id, _ := strconv.Atoi(idStr)
 	if err := models.DeleteNotificacionTipo(id); err == nil {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -608,53 +608,9 @@
                 ],
                 "description": "get MetodoHttp",
                 "operationId": "MetodoHttpController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.MetodoHttp"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -664,23 +620,9 @@
                 ],
                 "description": "create MetodoHttp",
                 "operationId": "MetodoHttpController.Post",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for MetodoHttp content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.MetodoHttp"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.MetodoHttp"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -692,24 +634,9 @@
                 ],
                 "description": "get MetodoHttp by id",
                 "operationId": "MetodoHttpController.Get One",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The key for staticblock",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.MetodoHttp"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -719,33 +646,9 @@
                 ],
                 "description": "update the MetodoHttp",
                 "operationId": "MetodoHttpController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for MetodoHttp content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.MetodoHttp"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.MetodoHttp"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -755,21 +658,9 @@
                 ],
                 "description": "delete the MetodoHttp",
                 "operationId": "MetodoHttpController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -781,53 +672,9 @@
                 ],
                 "description": "get Notificacion",
                 "operationId": "NotificacionController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.Notificacion"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -837,23 +684,9 @@
                 ],
                 "description": "create Notificacion",
                 "operationId": "NotificacionController.Post",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for Notificacion content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.Notificacion"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.Notificacion"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -865,24 +698,9 @@
                 ],
                 "description": "get Notificacion by id",
                 "operationId": "NotificacionController.Get One",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The key for staticblock",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.Notificacion"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -892,33 +710,9 @@
                 ],
                 "description": "update the Notificacion",
                 "operationId": "NotificacionController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for Notificacion content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.Notificacion"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.Notificacion"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -928,21 +722,9 @@
                 ],
                 "description": "delete the Notificacion",
                 "operationId": "NotificacionController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -954,53 +736,9 @@
                 ],
                 "description": "get NotificacionConfiguracion",
                 "operationId": "NotificacionConfiguracionController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracion"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1010,23 +748,9 @@
                 ],
                 "description": "create NotificacionConfiguracion",
                 "operationId": "NotificacionConfiguracionController.Post",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionConfiguracion content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracion"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.NotificacionConfiguracion"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1038,23 +762,9 @@
                 ],
                 "description": "get a configuration",
                 "operationId": "NotificacionConfiguracionController.getConfiguracion",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for ShowConfiguration content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.ShowConfiguration"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} get success!"
-                    },
-                    "403": {
-                        "description": "profile is empty"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1066,24 +776,9 @@
                 ],
                 "description": "get NotificacionConfiguracion by id",
                 "operationId": "NotificacionConfiguracionController.Get One",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The key for staticblock",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracion"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1093,33 +788,9 @@
                 ],
                 "description": "update the NotificacionConfiguracion",
                 "operationId": "NotificacionConfiguracionController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionConfiguracion content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracion"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracion"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1129,21 +800,9 @@
                 ],
                 "description": "delete the NotificacionConfiguracion",
                 "operationId": "NotificacionConfiguracionController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1155,53 +814,9 @@
                 ],
                 "description": "get NotificacionConfiguracionPerfil",
                 "operationId": "NotificacionConfiguracionPerfilController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracionPerfil"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1211,23 +826,9 @@
                 ],
                 "description": "create NotificacionConfiguracionPerfil",
                 "operationId": "NotificacionConfiguracionPerfilController.Post",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionConfiguracionPerfil content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracionPerfil"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.NotificacionConfiguracionPerfil"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1239,24 +840,9 @@
                 ],
                 "description": "get NotificacionConfiguracionPerfil by id",
                 "operationId": "NotificacionConfiguracionPerfilController.Get One",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The key for staticblock",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracionPerfil"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1266,33 +852,9 @@
                 ],
                 "description": "update the NotificacionConfiguracionPerfil",
                 "operationId": "NotificacionConfiguracionPerfilController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionConfiguracionPerfil content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracionPerfil"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionConfiguracionPerfil"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1302,21 +864,9 @@
                 ],
                 "description": "delete the NotificacionConfiguracionPerfil",
                 "operationId": "NotificacionConfiguracionPerfilController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1328,53 +878,9 @@
                 ],
                 "description": "get NotificacionEstado",
                 "operationId": "NotificacionEstadoController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstado"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1384,23 +890,9 @@
                 ],
                 "description": "create NotificacionEstado",
                 "operationId": "NotificacionEstadoController.Post",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionEstado content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstado"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.NotificacionEstado"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1412,24 +904,9 @@
                 ],
                 "description": "get NotificacionEstado by id",
                 "operationId": "NotificacionEstadoController.Get One",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The key for staticblock",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstado"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1439,33 +916,9 @@
                 ],
                 "description": "update the NotificacionEstado",
                 "operationId": "NotificacionEstadoController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionEstado content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstado"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstado"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1475,21 +928,9 @@
                 ],
                 "description": "delete the NotificacionEstado",
                 "operationId": "NotificacionEstadoController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1501,53 +942,9 @@
                 ],
                 "description": "get NotificacionEstadoUsuario",
                 "operationId": "NotificacionEstadoUsuarioController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstadoUsuario"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1574,6 +971,9 @@
                     },
                     "400": {
                         "description": "the request contains incorrect syntax"
+                    },
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1585,21 +985,9 @@
                 ],
                 "description": "change state of notifications",
                 "operationId": "NotificacionEstadoUsuarioController.changeStateNoView",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "usuario",
-                        "description": "The user you want to update",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} get success!"
-                    },
-                    "403": {
-                        "description": "body is empty"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1611,22 +999,9 @@
                 ],
                 "description": "create NotificacionEstadoUsuario",
                 "operationId": "NotificacionEstadoUsuarioController.changeStateNoView",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The notification you want to update",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.NotificacionEstadoUsuario"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1638,28 +1013,9 @@
                 ],
                 "description": "get all old notification",
                 "operationId": "NotificacionEstadoUsuarioController.getOldNotification",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "roles",
-                        "description": "The profile you want to consult",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "usuario",
-                        "description": "The user you want to consult",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} get success!"
-                    },
-                    "403": {
-                        "description": "profile is empty"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1671,23 +1027,9 @@
                 ],
                 "description": "create pushNotificationUser",
                 "operationId": "NotificacionEstadoUsuarioController.pushNotificationUser",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionEstadoUsuario content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionUsuarioMasiva"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.NotificacionEstadoUsuario"
-                    },
-                    "403": {
-                        "description": "body is empty"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1717,6 +1059,9 @@
                     },
                     "404": {
                         "description": "not found resource"
+                    },
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1726,33 +1071,9 @@
                 ],
                 "description": "update the NotificacionEstadoUsuario",
                 "operationId": "NotificacionEstadoUsuarioController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionEstadoUsuario content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstadoUsuario"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionEstadoUsuario"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1762,21 +1083,9 @@
                 ],
                 "description": "delete the NotificacionEstadoUsuario",
                 "operationId": "NotificacionEstadoUsuarioController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1788,53 +1097,9 @@
                 ],
                 "description": "get NotificacionTipo",
                 "operationId": "NotificacionTipoController.Get All",
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "query",
-                        "description": "Filter. e.g. col1:v1,col2:v2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "fields",
-                        "description": "Fields returned. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "sortby",
-                        "description": "Sorted-by fields. e.g. col1,col2 ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "order",
-                        "description": "Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ...",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "description": "Limit the size of result set. Must be an integer",
-                        "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "offset",
-                        "description": "Start position of result set. Must be an integer",
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionTipo"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1844,23 +1109,9 @@
                 ],
                 "description": "create NotificacionTipo",
                 "operationId": "NotificacionTipoController.Post",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionTipo content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionTipo"
-                        }
-                    }
-                ],
                 "responses": {
-                    "201": {
-                        "description": "{int} models.NotificacionTipo"
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -1872,24 +1123,9 @@
                 ],
                 "description": "get NotificacionTipo by id",
                 "operationId": "NotificacionTipoController.Get One",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The key for staticblock",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionTipo"
-                        }
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1899,33 +1135,9 @@
                 ],
                 "description": "update the NotificacionTipo",
                 "operationId": "NotificacionTipoController.Put",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to update",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "body for NotificacionTipo content",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionTipo"
-                        }
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/models.NotificacionTipo"
-                        }
-                    },
-                    "400": {
-                        "description": "the request contains incorrect syntax"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             },
@@ -1935,21 +1147,9 @@
                 ],
                 "description": "delete the NotificacionTipo",
                 "operationId": "NotificacionTipoController.Delete",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "The id you want to delete",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "{string} delete success!"
-                    },
-                    "404": {
-                        "description": "not found resource"
+                    "410": {
+                        "description": "Controlador archivado"
                     }
                 }
             }
@@ -2724,21 +1924,6 @@
                 }
             }
         },
-        "models.NotificacionUsuarioMasiva": {
-            "title": "NotificacionUsuarioMasiva",
-            "type": "object",
-            "properties": {
-                "Notificacion": {
-                    "$ref": "#/definitions/models.Notificacion"
-                },
-                "Usuarios": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
         "models.Parametro": {
             "title": "Parametro",
             "type": "object",
@@ -2787,24 +1972,6 @@
                 },
                 "Perfil": {
                     "$ref": "#/definitions/models.Perfil"
-                }
-            }
-        },
-        "models.ShowConfiguration": {
-            "title": "ShowConfiguration",
-            "type": "object",
-            "properties": {
-                "Aplicacion": {
-                    "type": "string"
-                },
-                "EndPoint": {
-                    "type": "string"
-                },
-                "MetodoHttp": {
-                    "type": "string"
-                },
-                "Tipo": {
-                    "type": "string"
                 }
             }
         }

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -406,632 +406,228 @@ paths:
       - metodo_http
       description: get MetodoHttp
       operationId: MetodoHttpController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.MetodoHttp'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - metodo_http
       description: create MetodoHttp
       operationId: MetodoHttpController.Post
-      parameters:
-      - in: body
-        name: body
-        description: body for MetodoHttp content
-        required: true
-        schema:
-          $ref: '#/definitions/models.MetodoHttp'
       responses:
-        "201":
-          description: '{int} models.MetodoHttp'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /metodo_http/{id}:
     get:
       tags:
       - metodo_http
       description: get MetodoHttp by id
       operationId: MetodoHttpController.Get One
-      parameters:
-      - in: path
-        name: id
-        description: The key for staticblock
-        required: true
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.MetodoHttp'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - metodo_http
       description: update the MetodoHttp
       operationId: MetodoHttpController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for MetodoHttp content
-        required: true
-        schema:
-          $ref: '#/definitions/models.MetodoHttp'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.MetodoHttp'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - metodo_http
       description: delete the MetodoHttp
       operationId: MetodoHttpController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /notificacion/:
     get:
       tags:
       - notificacion
       description: get Notificacion
       operationId: NotificacionController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.Notificacion'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - notificacion
       description: create Notificacion
       operationId: NotificacionController.Post
-      parameters:
-      - in: body
-        name: body
-        description: body for Notificacion content
-        required: true
-        schema:
-          $ref: '#/definitions/models.Notificacion'
       responses:
-        "201":
-          description: '{int} models.Notificacion'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion/{id}:
     get:
       tags:
       - notificacion
       description: get Notificacion by id
       operationId: NotificacionController.Get One
-      parameters:
-      - in: path
-        name: id
-        description: The key for staticblock
-        required: true
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.Notificacion'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - notificacion
       description: update the Notificacion
       operationId: NotificacionController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for Notificacion content
-        required: true
-        schema:
-          $ref: '#/definitions/models.Notificacion'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.Notificacion'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - notificacion
       description: delete the Notificacion
       operationId: NotificacionController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /notificacion_configuracion/:
     get:
       tags:
       - notificacion_configuracion
       description: get NotificacionConfiguracion
       operationId: NotificacionConfiguracionController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionConfiguracion'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - notificacion_configuracion
       description: create NotificacionConfiguracion
       operationId: NotificacionConfiguracionController.Post
-      parameters:
-      - in: body
-        name: body
-        description: body for NotificacionConfiguracion content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionConfiguracion'
       responses:
-        "201":
-          description: '{int} models.NotificacionConfiguracion'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion_configuracion/{id}:
     get:
       tags:
       - notificacion_configuracion
       description: get NotificacionConfiguracion by id
       operationId: NotificacionConfiguracionController.Get One
-      parameters:
-      - in: path
-        name: id
-        description: The key for staticblock
-        required: true
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionConfiguracion'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - notificacion_configuracion
       description: update the NotificacionConfiguracion
       operationId: NotificacionConfiguracionController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for NotificacionConfiguracion content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionConfiguracion'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionConfiguracion'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - notificacion_configuracion
       description: delete the NotificacionConfiguracion
       operationId: NotificacionConfiguracionController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /notificacion_configuracion/getConfiguracion/:
     post:
       tags:
       - notificacion_configuracion
       description: get a configuration
       operationId: NotificacionConfiguracionController.getConfiguracion
-      parameters:
-      - in: body
-        name: body
-        description: body for ShowConfiguration content
-        required: true
-        schema:
-          $ref: '#/definitions/models.ShowConfiguration'
       responses:
-        "200":
-          description: '{string} get success!'
-        "403":
-          description: profile is empty
+        "410":
+          description: Controlador archivado
   /notificacion_configuracion_perfil/:
     get:
       tags:
       - notificacion_configuracion_perfil
       description: get NotificacionConfiguracionPerfil
       operationId: NotificacionConfiguracionPerfilController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionConfiguracionPerfil'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - notificacion_configuracion_perfil
       description: create NotificacionConfiguracionPerfil
       operationId: NotificacionConfiguracionPerfilController.Post
-      parameters:
-      - in: body
-        name: body
-        description: body for NotificacionConfiguracionPerfil content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionConfiguracionPerfil'
       responses:
-        "201":
-          description: '{int} models.NotificacionConfiguracionPerfil'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion_configuracion_perfil/{id}:
     get:
       tags:
       - notificacion_configuracion_perfil
       description: get NotificacionConfiguracionPerfil by id
       operationId: NotificacionConfiguracionPerfilController.Get One
-      parameters:
-      - in: path
-        name: id
-        description: The key for staticblock
-        required: true
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionConfiguracionPerfil'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - notificacion_configuracion_perfil
       description: update the NotificacionConfiguracionPerfil
       operationId: NotificacionConfiguracionPerfilController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for NotificacionConfiguracionPerfil content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionConfiguracionPerfil'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionConfiguracionPerfil'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - notificacion_configuracion_perfil
       description: delete the NotificacionConfiguracionPerfil
       operationId: NotificacionConfiguracionPerfilController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /notificacion_estado/:
     get:
       tags:
       - notificacion_estado
       description: get NotificacionEstado
       operationId: NotificacionEstadoController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionEstado'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - notificacion_estado
       description: create NotificacionEstado
       operationId: NotificacionEstadoController.Post
-      parameters:
-      - in: body
-        name: body
-        description: body for NotificacionEstado content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionEstado'
       responses:
-        "201":
-          description: '{int} models.NotificacionEstado'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion_estado/{id}:
     get:
       tags:
       - notificacion_estado
       description: get NotificacionEstado by id
       operationId: NotificacionEstadoController.Get One
-      parameters:
-      - in: path
-        name: id
-        description: The key for staticblock
-        required: true
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionEstado'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - notificacion_estado
       description: update the NotificacionEstado
       operationId: NotificacionEstadoController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for NotificacionEstado content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionEstado'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionEstado'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - notificacion_estado
       description: delete the NotificacionEstado
       operationId: NotificacionEstadoController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /notificacion_estado_usuario/:
     get:
       tags:
       - notificacion_estado_usuario
       description: get NotificacionEstadoUsuario
       operationId: NotificacionEstadoUsuarioController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionEstadoUsuario'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - notificacion_estado_usuario
@@ -1049,6 +645,8 @@ paths:
           description: '{int} models.NotificacionEstadoUsuario'
         "400":
           description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion_estado_usuario/{id}:
     get:
       tags:
@@ -1068,236 +666,102 @@ paths:
             $ref: '#/definitions/models.NotificacionEstadoUsuario'
         "404":
           description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - notificacion_estado_usuario
       description: update the NotificacionEstadoUsuario
       operationId: NotificacionEstadoUsuarioController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for NotificacionEstadoUsuario content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionEstadoUsuario'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionEstadoUsuario'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - notificacion_estado_usuario
       description: delete the NotificacionEstadoUsuario
       operationId: NotificacionEstadoUsuarioController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /notificacion_estado_usuario/changeStateNoView/{usuario}:
     post:
       tags:
       - notificacion_estado_usuario
       description: change state of notifications
       operationId: NotificacionEstadoUsuarioController.changeStateNoView
-      parameters:
-      - in: path
-        name: usuario
-        description: The user you want to update
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} get success!'
-        "403":
-          description: body is empty
+        "410":
+          description: Controlador archivado
   /notificacion_estado_usuario/changeStateToView/{id}:
     get:
       tags:
       - notificacion_estado_usuario
       description: create NotificacionEstadoUsuario
       operationId: NotificacionEstadoUsuarioController.changeStateNoView
-      parameters:
-      - in: path
-        name: id
-        description: The notification you want to update
-        required: true
-        type: integer
-        format: int64
       responses:
-        "201":
-          description: '{int} models.NotificacionEstadoUsuario'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion_estado_usuario/getOldNotification/{roles}/{usuario}:
     get:
       tags:
       - notificacion_estado_usuario
       description: get all old notification
       operationId: NotificacionEstadoUsuarioController.getOldNotification
-      parameters:
-      - in: path
-        name: roles
-        description: The profile you want to consult
-        required: true
-        type: string
-      - in: path
-        name: usuario
-        description: The user you want to consult
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} get success!'
-        "403":
-          description: profile is empty
+        "410":
+          description: Controlador archivado
   /notificacion_estado_usuario/pushNotificationUser:
     post:
       tags:
       - notificacion_estado_usuario
       description: create pushNotificationUser
       operationId: NotificacionEstadoUsuarioController.pushNotificationUser
-      parameters:
-      - in: body
-        name: body
-        description: body for NotificacionEstadoUsuario content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionUsuarioMasiva'
       responses:
-        "201":
-          description: '{int} models.NotificacionEstadoUsuario'
-        "403":
-          description: body is empty
+        "410":
+          description: Controlador archivado
   /notificacion_tipo/:
     get:
       tags:
       - notificacion_tipo
       description: get NotificacionTipo
       operationId: NotificacionTipoController.Get All
-      parameters:
-      - in: query
-        name: query
-        description: Filter. e.g. col1:v1,col2:v2 ...
-        type: string
-      - in: query
-        name: fields
-        description: Fields returned. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: sortby
-        description: Sorted-by fields. e.g. col1,col2 ...
-        type: string
-      - in: query
-        name: order
-        description: Order corresponding to each sortby field, if single value, apply
-          to all sortby fields. e.g. desc,asc ...
-        type: string
-      - in: query
-        name: limit
-        description: Limit the size of result set. Must be an integer
-        type: string
-      - in: query
-        name: offset
-        description: Start position of result set. Must be an integer
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionTipo'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     post:
       tags:
       - notificacion_tipo
       description: create NotificacionTipo
       operationId: NotificacionTipoController.Post
-      parameters:
-      - in: body
-        name: body
-        description: body for NotificacionTipo content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionTipo'
       responses:
-        "201":
-          description: '{int} models.NotificacionTipo'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
   /notificacion_tipo/{id}:
     get:
       tags:
       - notificacion_tipo
       description: get NotificacionTipo by id
       operationId: NotificacionTipoController.Get One
-      parameters:
-      - in: path
-        name: id
-        description: The key for staticblock
-        required: true
-        type: string
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionTipo'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
     put:
       tags:
       - notificacion_tipo
       description: update the NotificacionTipo
       operationId: NotificacionTipoController.Put
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to update
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: body for NotificacionTipo content
-        required: true
-        schema:
-          $ref: '#/definitions/models.NotificacionTipo'
       responses:
-        "200":
-          description: ""
-          schema:
-            $ref: '#/definitions/models.NotificacionTipo'
-        "400":
-          description: the request contains incorrect syntax
+        "410":
+          description: Controlador archivado
     delete:
       tags:
       - notificacion_tipo
       description: delete the NotificacionTipo
       operationId: NotificacionTipoController.Delete
-      parameters:
-      - in: path
-        name: id
-        description: The id you want to delete
-        required: true
-        type: string
       responses:
-        "200":
-          description: '{string} delete success!'
-        "404":
-          description: not found resource
+        "410":
+          description: Controlador archivado
   /parametro/:
     get:
       tags:
@@ -1814,16 +1278,6 @@ definitions:
         format: int64
       Nombre:
         type: string
-  models.NotificacionUsuarioMasiva:
-    title: NotificacionUsuarioMasiva
-    type: object
-    properties:
-      Notificacion:
-        $ref: '#/definitions/models.Notificacion'
-      Usuarios:
-        type: array
-        items:
-          type: string
   models.Parametro:
     title: Parametro
     type: object
@@ -1859,18 +1313,6 @@ definitions:
         $ref: '#/definitions/models.MenuOpcion'
       Perfil:
         $ref: '#/definitions/models.Perfil'
-  models.ShowConfiguration:
-    title: ShowConfiguration
-    type: object
-    properties:
-      Aplicacion:
-        type: string
-      EndPoint:
-        type: string
-      MetodoHttp:
-        type: string
-      Tipo:
-        type: string
 tags:
 - name: notificacion_estado_usuario
   description: |


### PR DESCRIPTION
Por solicitud de desactivar lo relacionado a la parte de notificaciones, los controladores asociados a notificaciones ahora retornan un [HTTP 410: Gone](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410)
